### PR TITLE
feat: always call gtk_window_set_title in yaru_window_set_title

### DIFF
--- a/packages/yaru_window_linux/linux/yaru_window.cc
+++ b/packages/yaru_window_linux/linux/yaru_window.cc
@@ -150,9 +150,8 @@ void yaru_window_set_title(GtkWindow* window, const gchar* title) {
   GtkWidget* titlebar = find_header_bar(window);
   if (titlebar != nullptr) {
     g_object_set(titlebar, "title", title, nullptr);
-  } else {
-    gtk_window_set_title(window, title);
   }
+  gtk_window_set_title(window, title);
 }
 
 void yaru_window_hide_title(GtkWindow* window) {


### PR DESCRIPTION
Makes sure the title of the GTK window is updated even when no GTK title bar is present, since e.g. the 'overview' in GNOME uses the GTK window title.

Ref: https://github.com/ubuntu/app-center/issues/1425